### PR TITLE
The version of iText has problems rendering HTML that uses Bootstrap CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+target-eclipse
 plugin.xml
 docs
 *.log
@@ -6,3 +7,7 @@ docs
 .DS_Store
 grails-rendering-*
 .settings
+.gradle
+.project
+.classpath
+build

--- a/RenderingGrailsPlugin.groovy
+++ b/RenderingGrailsPlugin.groovy
@@ -15,7 +15,7 @@
  */
 class RenderingGrailsPlugin {
 
-	def version = "1.0.1-SNAPSHOT"
+	def version = "1.0.2-SNAPSHOT"
 	def grailsVersion = "1.3.0 > *"
 
 	def pluginExcludes = [

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -36,7 +36,7 @@ grails.project.dependency.resolution = {
 	def seleniumVersion = "2.32.0"
 
 	dependencies {
-		compile("org.xhtmlrenderer:core-renderer:R8")
+		compile("org.xhtmlrenderer:flying-saucer-pdf-itext5:9.0.7")
 		compile("com.lowagie:itext:2.1.0")
 		test("org.apache.pdfbox:pdfbox:1.0.0") {
 			exclude 'jempbox'


### PR DESCRIPTION
The problem was fixed in later versions, so a version upgrade is necessary.

Inclusion of Bootstrap caused 

> org.xhtmlrenderer.render.BlockBox cannot be cast to org.xhtmlrenderer.newtable.TableBox
- Upgraded from org.xhtmlrenderer:core-renderer:R8 to org.xhtmlrenderer:flying-saucer-pdf-itext5:9.0.7
- Upgraded artifact to 1.0.2-SNAPSHOT
